### PR TITLE
Fix requirements and switch to python 3.10

### DIFF
--- a/examples/socketio/Dockerfile
+++ b/examples/socketio/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim-buster
+FROM python:3.10-slim-buster
 
 RUN apt-get update && \
     apt-get upgrade -y && \

--- a/examples/socketio/requirements.txt
+++ b/examples/socketio/requirements.txt
@@ -1,4 +1,14 @@
-aiohttp==3.7.4
-python-socketio==4.4.0
+aiohttp==3.8.3
+aiosignal==1.3.1
+async-timeout==4.0.2
 asyncio==3.4.3
-git+git://github.com/NeiroNx/python-dvr@master#egg=python-dvr
+attrs==22.1.0
+bidict==0.22.0
+charset-normalizer==2.1.1
+frozenlist==1.3.3
+idna==3.4
+multidict==6.0.2
+python-dvr @ git+https://github.com/NeiroNx/python-dvr@06ff6dc0082767e7c9f23401f828533459f783a4
+python-engineio==4.3.4
+python-socketio==5.7.2
+yarl==1.8.1


### PR DESCRIPTION
Actually works with that set of requirements.
Also github no longer allows "git" protocol, so switched to https.